### PR TITLE
change default binding IP from 10.140.54.61 to 0.0.0.0

### DIFF
--- a/video_miniGPT4/demo.py
+++ b/video_miniGPT4/demo.py
@@ -147,4 +147,4 @@ with gr.Blocks() as demo:
 
 
 # demo.launch(share=True, enable_queue=True)
-demo.launch(server_name="10.140.54.61", server_port=10034)
+demo.launch(server_name="0.0.0.0", server_port=10034)

--- a/video_miniGPT4/demo_video.py
+++ b/video_miniGPT4/demo_video.py
@@ -145,4 +145,4 @@ with gr.Blocks() as demo:
 
 
 # demo.launch(share=True, enable_queue=True)
-demo.launch(server_name="10.140.54.61", server_port=10034)
+demo.launch(server_name="0.0.0.0", server_port=10034)


### PR DESCRIPTION
The demo files have your personal server's internal IP hardcoded as the listening IP. Default should be 0.0.0.0 so that you don't get an error when following the instructions to run the demo.