### PR TITLE
Fix mvbench.ipynb in Video-Chat2

### DIFF
--- a/video_chat2/mvbench.ipynb
+++ b/video_chat2/mvbench.ipynb
@@ -31,7 +31,7 @@
     "import io\n",
     "import json\n",
     "\n",
-    "from models.videochat2_it import VideoChat2_it\n",
+    "from models.videochat_vicuna.videochat2_it_vicuna import VideoChat2_it_vicuna as VideoChat2_it\n",
     "from utils.easydict import EasyDict\n",
     "import torch\n",
     "\n",


### PR DESCRIPTION
Hi,
The original code includes the line `models.videochat2_it import VideoChat2_it` to load the model. 
However, it seems that there is no `videochat2_it.py` file available to import the model configurations. 
To run the code successfully, I modified it to `models.videochat_vicuna.videochat2_it_vicuna import VideoChat2_it_vicuna as VideoChat2_it` to correctly load the model.