### PR TITLE
Fix BOS token embedding: use embed_tokens() instead of raw integer

### DIFF
--- a/video_chat/models/videochat_it.py
+++ b/video_chat/models/videochat_it.py
@@ -265,7 +265,10 @@ class VideoChat_it(Blip2Base):
         attention_mask = torch.zeros([batch_size, txt_len], dtype=torch.long).to(img_embeds.device)
         targets = torch.ones([batch_size, txt_len], dtype=torch.long).to(img_embeds.device).fill_(-100)
         # set bos_token
-        inputs_embeds[:, :1] = self.llama_tokenizer.bos_token_id
+        bos_embeds = self.llama_model.model.embed_tokens(
+            torch.tensor([[self.llama_tokenizer.bos_token_id]], device=inputs_embeds.device)
+        )
+        inputs_embeds[:, :1] = bos_embeds
         for idx in range(batch_size):
             input_len = min(input_embed_list[idx].shape[1], txt_len - 1)
             # if less than txt_len, the input will be padding

--- a/video_chat2/models/videochat_mistra/videochat2_it_hd_mistral.py
+++ b/video_chat2/models/videochat_mistra/videochat2_it_hd_mistral.py
@@ -368,7 +368,12 @@ class VideoChat2_it_hd_mistral(Blip2Base):
         attention_mask = torch.zeros([batch_size, txt_len], dtype=torch.long).to(device)
         targets = torch.ones([batch_size, txt_len], dtype=torch.long).to(device).fill_(-100)
         # set bos_token
-        inputs_embeds[:, :1] = self.mistral_tokenizer.bos_token_id
+        bos_token_id = torch.tensor([[self.mistral_tokenizer.bos_token_id]], device=inputs_embeds.device)
+        if self.use_lora:
+            bos_embeds = self.mistral_model.base_model.model.model.embed_tokens(bos_token_id)
+        else:
+            bos_embeds = self.mistral_model.model.embed_tokens(bos_token_id)
+        inputs_embeds[:, :1] = bos_embeds
         
         for idx in range(batch_size):
             input_len = min(input_embed_list[idx].shape[1], txt_len - 1)

--- a/video_chat2/models/videochat_mistra/videochat2_it_mistral.py
+++ b/video_chat2/models/videochat_mistra/videochat2_it_mistral.py
@@ -299,7 +299,12 @@ class VideoChat2_it_mistral(Blip2Base):
         attention_mask = torch.zeros([batch_size, txt_len], dtype=torch.long).to(img_embeds.device)
         targets = torch.ones([batch_size, txt_len], dtype=torch.long).to(img_embeds.device).fill_(-100)
         # set bos_token
-        inputs_embeds[:, :1] = self.mistral_tokenizer.bos_token_id
+        bos_token_id = torch.tensor([[self.mistral_tokenizer.bos_token_id]], device=inputs_embeds.device)
+        if self.use_lora:
+            bos_embeds = self.mistral_model.base_model.model.model.embed_tokens(bos_token_id)
+        else:
+            bos_embeds = self.mistral_model.model.embed_tokens(bos_token_id)
+        inputs_embeds[:, :1] = bos_embeds
         for idx in range(batch_size):
             input_len = min(input_embed_list[idx].shape[1], txt_len - 1)
             # if less than txt_len, the input will be padding

--- a/video_chat2/models/videochat_vicuna/videochat2_it_vicuna.py
+++ b/video_chat2/models/videochat_vicuna/videochat2_it_vicuna.py
@@ -296,7 +296,12 @@ class VideoChat2_it_vicuna(Blip2Base):
         attention_mask = torch.zeros([batch_size, txt_len], dtype=torch.long).to(img_embeds.device)
         targets = torch.ones([batch_size, txt_len], dtype=torch.long).to(img_embeds.device).fill_(-100)
         # set bos_token
-        inputs_embeds[:, :1] = self.llama_tokenizer.bos_token_id
+        bos_token_id = torch.tensor([[self.llama_tokenizer.bos_token_id]], device=inputs_embeds.device)
+        if self.use_lora:
+            bos_embeds = self.llama_model.base_model.model.model.embed_tokens(bos_token_id)
+        else:
+            bos_embeds = self.llama_model.model.embed_tokens(bos_token_id)
+        inputs_embeds[:, :1] = bos_embeds
         for idx in range(batch_size):
             input_len = min(input_embed_list[idx].shape[1], txt_len - 1)
             # if less than txt_len, the input will be padding


### PR DESCRIPTION
## Summary

- **Bug**: In the `forward()` methods across 4 model files, the BOS token position in `inputs_embeds` is set using the raw integer `bos_token_id` (e.g., `1`) instead of its actual embedding vector. Since `inputs_embeds` is a float tensor produced by `embed_tokens()`, assigning a scalar integer broadcasts that value across the entire embedding dimension, effectively corrupting the BOS position with a uniform constant instead of the learned BOS embedding.
- **Fix**: Pass `bos_token_id` through `embed_tokens()` to obtain the proper embedding vector before assigning it to `inputs_embeds[:, :1]`. The fix respects each file's model attribute path (`llama_model` vs `mistral_model`) and LoRA configuration (`base_model.model.model` vs `model`).

## Affected files

- `video_chat/models/videochat_it.py`
- `video_chat2/models/videochat_vicuna/videochat2_it_vicuna.py`
- `video_chat2/models/videochat_mistra/videochat2_it_mistral.py`
- `video_chat2/models/videochat_mistra/videochat2_it_hd_mistral.py`

## Before (buggy)

```python
# inputs_embeds is a float tensor of shape [B, seq_len, hidden_dim]
# bos_token_id is an integer (e.g., 1)
# This broadcasts the scalar 1 across all hidden_dim dimensions
inputs_embeds[:, :1] = self.llama_tokenizer.bos_token_id
```

## After (fixed)

```python
bos_token_id = torch.tensor([[self.llama_tokenizer.bos_token_id]], device=inputs_embeds.device)
if self.use_lora:
    bos_embeds = self.llama_model.base_model.model.model.embed_tokens(bos_token_id)
else:
    bos_embeds = self.llama_model.model.embed_tokens(bos_token_id)
inputs_embeds[:, :1] = bos_embeds
```

## Test plan

- [ ] Verify that `inputs_embeds[:, :1]` now contains a proper embedding vector (varying values across the hidden dimension) rather than a uniform scalar
- [ ] Run training on a small sample to confirm loss values are comparable or improved
- [ ] Check that inference outputs remain coherent with the corrected BOS embedding